### PR TITLE
Bump compat for JLD2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 LightGraphs = "1"
 julia = "1"
-JLD2 = "0.1"
+JLD2 = "0.1 - 0.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Tests pass locally, I think JLD2s `@load` and `@save` haven't changed behaviour in a way that would break this.

Closes #26 