### PR TITLE
Print information about static nature of graph in display

### DIFF
--- a/src/StaticGraphs.jl
+++ b/src/StaticGraphs.jl
@@ -61,6 +61,11 @@ function show(io::IO, g::AbstractStaticGraph)
     print(io, "{$(nv(g)), $(ne(g))} $dir simple static {$(vectype(g)), $(indtype(g))} graph")
 end
 
+function show(io::IO, ::MIME"text/plain", g::AbstractStaticGraph)
+    dir = is_directed(g) ? "directed" : "undirected"
+    print(io, "{$(nv(g)), $(ne(g))} $dir simple static {$(vectype(g)), $(indtype(g))} graph")
+end
+
 @inline function _fvrange(g::AbstractStaticGraph, s::Integer)
     @inbounds r_start = g.f_ind[s]
     @inbounds r_end = g.f_ind[s + 1] - 1


### PR DESCRIPTION
The `show` function is only overloaded for inline printing, but when displaying the graph, the information about its static nature is missing, potentially confusing users:
```
julia> g
{58089, 120148} directed simple Int32 graph

julia> (g, nothing)
({58089, 120148} directed simple static {Int32, Int32} graph, nothing)
```
This PR fixes that.