### PR TITLE
Strip trailing whitespace in README.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build status](https://github.com/JuliaGraphs/StaticGraphs.jl/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/JuliaGraphs/StaticGraphs.jl/actions/workflows/ci.yml?query=branch%3Amaster)
 [![codecov.io](http://codecov.io/github/JuliaGraphs/StaticGraphs.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaGraphs/StaticGraphs.jl?branch=master)
 
-Memory-efficient, performant graph structures optimized for large networks. 
+Memory-efficient, performant graph structures optimized for large networks.
 Uses [Graphs](https://github.com/JuliaGraphs/Graphs.jl).
 
 Note: adding/removing edges and vertices is not supported with this graph type.


### PR DESCRIPTION
It does not have any effect, but is just a bit cleaner.